### PR TITLE
Hotfix: wrong replacement in command path after rewrite to Laminas

### DIFF
--- a/src/Help.php
+++ b/src/Help.php
@@ -68,7 +68,7 @@ EOT;
         // Find relative command path
         $command = strtr(realpath($this->command) ?: $this->command, [
             getcwd() . DIRECTORY_SEPARATOR => '',
-            'laminascampus' . DIRECTORY_SEPARATOR . 'laminas-composer-autoloading' . DIRECTORY_SEPARATOR => '',
+            'laminas' . DIRECTORY_SEPARATOR . 'laminas-composer-autoloading' . DIRECTORY_SEPARATOR => '',
         ]);
 
         $this->helper->writeLine(sprintf(


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

During migration we had wrong replacement here, so help gives wrong command path.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
